### PR TITLE
Update ipl requirement

### DIFF
--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -7,7 +7,7 @@
 * MySQL or MariaDB
 * Icinga Web 2 modules:
   * [reactbundle](https://github.com/Icinga/icingaweb2-module-reactbundle) (>= 0.4)
-  * [Icinga PHP Library (ipl)](https://github.com/Icinga/icingaweb2-module-ipl) (>= 0.1)
+  * [Icinga PHP Library (ipl)](https://github.com/Icinga/icingaweb2-module-ipl) (>= 0.2.1)
   * [pdfexport](https://github.com/Icinga/icingaweb2-module-pdfexport) (>= 0.9)
 
 ## Database Setup


### PR DESCRIPTION
The reporting module needs the lastest ipl version (0.2.1). Otherwise it will fail:
```
Uncaught Error: Class 'ipl\Sql\Select' not found in /usr/share/icingaweb2/modules/reporting/library/Reporting/Database.php:31
```