### PR TITLE
Add autosubmit class to Timeframe field in ReportForm

### DIFF
--- a/library/Reporting/Web/Forms/ReportForm.php
+++ b/library/Reporting/Web/Forms/ReportForm.php
@@ -36,7 +36,8 @@ class ReportForm extends Form
         $this->addElement('select', 'timeframe', [
             'required'  => true,
             'label'     => 'Timeframe',
-            'options'   => [null => 'Please choose'] + $this->listTimeframes()
+            'options'   => [null => 'Please choose'] + $this->listTimeframes(),
+            'class'     => 'autosubmit'
         ]);
 
         $this->addElement('select', 'reportlet', [


### PR DESCRIPTION
The Timeframe field in ReportForm has no `autosubmit` class, but it can be useful for Reportlet Form validation.