### PR TITLE
Fix timeframe creation with PostgreSQL

### DIFF
--- a/library/Reporting/Web/Forms/TimeframeForm.php
+++ b/library/Reporting/Web/Forms/TimeframeForm.php
@@ -93,7 +93,7 @@ class TimeframeForm extends Form
             $db->insert('timeframe', [
                 'name'  => $values['name'],
                 'start' => $values['start'],
-                'end'   => $values['end'],
+                '"end"'   => $values['end'],
                 'ctime' => $now,
                 'mtime' => $now
             ]);
@@ -101,7 +101,7 @@ class TimeframeForm extends Form
             $db->update('timeframe', [
                 'name'  => $values['name'],
                 'start' => $values['start'],
-                'end'   => $values['end'],
+                '"end"'   => $values['end'],
                 'mtime' => $now
             ], ['id = ?' => $this->id]);
         }


### PR DESCRIPTION
end is a keyword in PostgreSQL and needs to be quoted when it is used as a key in a named array.