### PR TITLE
Added macro time_frame_absolue

### DIFF
--- a/application/controllers/TemplateController.php
+++ b/application/controllers/TemplateController.php
@@ -27,9 +27,10 @@ class TemplateController extends Controller
 
         $template
             ->setMacros([
-                'date'       => (new DateTime())->format('jS M, Y'),
-                'time_frame' => 'Time Frame',
-                'title'      => 'Icinga Report Preview'
+                'date'                => (new DateTime())->format('jS M, Y'),
+                'time_frame'          => 'Time Frame',
+                'time_frame_absolute' => 'Time Frame (absolute)',
+                'title'               => 'Icinga Report Preview'
             ])
             ->setPreview(true);
 

--- a/library/Reporting/Report.php
+++ b/library/Reporting/Report.php
@@ -362,9 +362,14 @@ class Report
 
         if ($this->template !== null) {
             $this->template->setMacros([
-                'date'       => (new DateTime())->format('jS M, Y'),
-                'time_frame' => $this->timeframe->getName(),
-                'title'      => $this->name
+                'title'               => $this->name,
+                'date'                => (new DateTime())->format('jS M, Y'),
+                'time_frame'          => $this->timeframe->getName(),
+                'time_frame_absolute' => sprintf(
+                    'From %s to %s',
+                    $this->timeframe->getTimerange()->getStart()->format('r'),
+                    $this->timeframe->getTimerange()->getEnd()->format('r')
+                )
             ]);
 
             $html->setCoverPage($this->template->getCoverPage()->setMacros($this->template->getMacros()));

--- a/library/Reporting/Web/Forms/TemplateForm.php
+++ b/library/Reporting/Web/Forms/TemplateForm.php
@@ -264,6 +264,7 @@ class TemplateForm extends CompatForm
                     'options' => [
                         'report_title'          => 'Report Title',
                         'time_frame'            => 'Time Frame',
+                        'time_frame_absolute'   => 'Time Frame (absolute)',
                         'page_number'           => 'Page Number',
                         'total_number_of_pages' => 'Total Number of Pages',
                         'page_of'               => 'Page Number + Total Number of Pages',

--- a/library/Reporting/Web/Widget/HeaderOrFooter.php
+++ b/library/Reporting/Web/Widget/HeaderOrFooter.php
@@ -35,6 +35,9 @@ class HeaderOrFooter extends HtmlDocument
             case 'time_frame':
                 $resolved = Html::tag('p', $this->getMacro('time_frame'));
                 break;
+            case 'time_frame_absolute':
+                $resolved = Html::tag('p', $this->getMacro('time_frame_absolute'));
+                break;
             case 'page_number':
                 $resolved = Html::tag('span', ['class' => 'pageNumber']);
                 break;


### PR DESCRIPTION
This PR just adds another macro "time_frame_absolute" for being used in a report template.
time_frame_absolute  shows the complete time frame of the report in human-readable form as produced by PHP's 
`(new DateTime())->format ('r')`

e.g.:
"Tue, 01 Dec 2020 00:00:00 +0100 - Thu, 31 Dec 2020 23:59:59 +0100".

I needed this because my report consumers would like to see the actual time frame of a report being explicitly printed in the report (instead of just the name of the time period, e.g. "last month").