### PR TITLE
`ScheduleForm`, `TemplateForm`, `ReportForm`, and `TimeFrameForm` Refactoring

### DIFF
--- a/application/controllers/ReportController.php
+++ b/application/controllers/ReportController.php
@@ -67,12 +67,12 @@ class ReportController extends Controller
             $values[$name] = $value;
         }
 
-        $form = new ReportForm();
-        $form->setId($this->report->getId());
-        $form->populate($values);
-        $form->handleRequest(ServerRequest::fromGlobals());
-
-        $this->redirectForm($form, 'reporting/reports');
+        $form = ReportForm::fromId($this->report->getId())
+            ->on(ReportForm::ON_SUCCESS, function () {
+                $this->redirectNow('reporting/reports');
+            })
+            ->populate($values)
+            ->handleRequest(ServerRequest::fromGlobals());
 
         $this->addContent($form);
     }
@@ -84,12 +84,12 @@ class ReportController extends Controller
         Environment::raiseExecutionTime();
         Environment::raiseMemoryLimit();
 
-        $form = new SendForm();
-        $form
+        $form = (new SendForm())
             ->setReport($this->report)
+            ->on(SendForm::ON_SUCCESS, function () {
+                $this->redirectNow("reporting/report?id={$this->report->getId()}");
+            })
             ->handleRequest(ServerRequest::fromGlobals());
-
-        $this->redirectForm($form, "reporting/report?id={$this->report->getId()}");
 
         $this->addContent($form);
     }

--- a/application/controllers/ReportController.php
+++ b/application/controllers/ReportController.php
@@ -99,12 +99,11 @@ class ReportController extends Controller
         $this->assertPermission('reporting/schedules');
         $this->addTitleTab('Schedule');
 
-        $form = new ScheduleForm();
-        $form
-            ->setReport($this->report)
+        $form = ScheduleForm::fromReport($this->report)
+            ->on(ScheduleForm::ON_SUCCESS, function () {
+                $this->redirectNow("reporting/report?id={$this->report->getId()}");
+            })
             ->handleRequest(ServerRequest::fromGlobals());
-
-        $this->redirectForm($form, "reporting/report?id={$this->report->getId()}");
 
         $this->addContent($form);
     }

--- a/application/controllers/ReportsController.php
+++ b/application/controllers/ReportsController.php
@@ -95,10 +95,11 @@ class ReportsController extends Controller
         $this->assertPermission('reporting/reports');
         $this->addTitleTab($this->translate('New Report'));
 
-        $form = new ReportForm();
-        $form->handleRequest(ServerRequest::fromGlobals());
-
-        $this->redirectForm($form, 'reporting/reports');
+        $form = (new ReportForm())
+            ->on(ReportForm::ON_SUCCESS, function () {
+                $this->redirectNow('reporting/reports');
+            })
+            ->handleRequest(ServerRequest::fromGlobals());
 
         $this->addContent($form);
     }

--- a/application/controllers/TemplateController.php
+++ b/application/controllers/TemplateController.php
@@ -57,12 +57,11 @@ class TemplateController extends Controller
 
         $template->settings = json_decode($template->settings, true);
 
-        $form = (new TemplateForm())
-            ->setTemplate($template);
-
-        $form->handleRequest(ServerRequest::fromGlobals());
-
-        $this->redirectForm($form, 'reporting/templates');
+        $form = TemplateForm::fromTemplate($template)
+            ->on(TemplateForm::ON_SUCCESS, function () {
+                $this->redirectNow('reporting/templates');
+            })
+            ->handleRequest(ServerRequest::fromGlobals());
 
         $this->addContent($form);
     }

--- a/application/controllers/TemplatesController.php
+++ b/application/controllers/TemplatesController.php
@@ -96,11 +96,11 @@ class TemplatesController extends Controller
         $this->assertPermission('reporting/templates');
         $this->addTitleTab('New Template');
 
-        $form = new TemplateForm();
-
-        $form->handleRequest(ServerRequest::fromGlobals());
-
-        $this->redirectForm($form, 'reporting/templates');
+        $form = (new TemplateForm())
+            ->on(TemplateForm::ON_SUCCESS, function () {
+                $this->redirectNow('reporting/templates');
+            })
+            ->handleRequest(ServerRequest::fromGlobals());
 
         $this->addContent($form);
     }

--- a/application/controllers/TimeframeController.php
+++ b/application/controllers/TimeframeController.php
@@ -34,14 +34,12 @@ class TimeframeController extends Controller
         ];
 
 
-        $form = (new TimeframeForm())
-            ->setId($this->timeframe->getId());
-
-        $form->populate($values);
-
-        $form->handleRequest(ServerRequest::fromGlobals());
-
-        $this->redirectForm($form, 'reporting/timeframes');
+        $form = TimeframeForm::fromId($this->timeframe->getId())
+            ->on(TimeframeForm::ON_SUCCESS, function () {
+                $this->redirectNow('reporting/timeframes');
+            })
+            ->populate($values)
+            ->handleRequest(ServerRequest::fromGlobals());
 
         $this->addContent($form);
     }

--- a/application/controllers/TimeframesController.php
+++ b/application/controllers/TimeframesController.php
@@ -94,10 +94,11 @@ class TimeframesController extends Controller
         $this->assertPermission('reporting/timeframes');
         $this->addTitleTab($this->translate('New Timeframe'));
 
-        $form = new TimeframeForm();
-        $form->handleRequest(ServerRequest::fromGlobals());
-
-        $this->redirectForm($form, 'reporting/timeframes');
+        $form = (new TimeframeForm())
+            ->on(TimeframeForm::ON_SUCCESS, function () {
+                $this->redirectNow('reporting/timeframes');
+            })
+            ->handleRequest(ServerRequest::fromGlobals());
 
         $this->addContent($form);
     }

--- a/library/Reporting/Web/Controller.php
+++ b/library/Reporting/Web/Controller.php
@@ -4,19 +4,8 @@
 
 namespace Icinga\Module\Reporting\Web;
 
-use ipl\Html\Form;
 use ipl\Web\Compat\CompatController;
 
 class Controller extends CompatController
 {
-    protected function redirectForm(Form $form, $url)
-    {
-        if (
-            $form->hasBeenSubmitted()
-            && ((isset($form->valid) && $form->valid === true)
-                || $form->isValid())
-        ) {
-            $this->redirectNow($url);
-        }
-    }
 }

--- a/library/Reporting/Web/Forms/ReportForm.php
+++ b/library/Reporting/Web/Forms/ReportForm.php
@@ -17,16 +17,26 @@ class ReportForm extends CompatForm
     use Database;
     use ProvidedReports;
 
-    /** @var bool Hack to disable the {@link onSuccess()} code upon deletion of the report */
-    protected $callOnSuccess;
-
     protected $id;
 
-    public function setId($id)
+    /**
+     * Create a new form instance with the given report id
+     *
+     * @param $id
+     *
+     * @return static
+     */
+    public static function fromId($id): self
     {
-        $this->id = $id;
+        $form = new static();
+        $form->id = $id;
 
-        return $this;
+        return $form;
+    }
+
+    public function hasBeenSubmitted(): bool
+    {
+        return $this->hasBeenSent() && ($this->getPopulatedValue('submit') || $this->getPopulatedValue('remove'));
     }
 
     protected function assemble()
@@ -86,27 +96,18 @@ class ReportForm extends CompatForm
             ]);
             $this->registerElement($removeButton);
             $this->getElement('submit')->getWrapper()->prepend($removeButton);
-
-            if ($removeButton->hasBeenPressed()) {
-                $this->getDb()->delete('report', ['id = ?' => $this->id]);
-
-                // Stupid cheat because ipl/html is not capable of multiple submit buttons
-                $this->getSubmitButton()->setValue($this->getSubmitButton()->getButtonLabel());
-                $this->callOnSuccess = false;
-                $this->valid = true;
-
-                return;
-            }
         }
     }
 
     public function onSuccess()
     {
-        if ($this->callOnSuccess === false) {
+        $db = $this->getDb();
+
+        if ($this->getPopulatedValue('remove')) {
+            $db->delete('report', ['id = ?' => $this->id]);
+
             return;
         }
-
-        $db = $this->getDb();
 
         $values = $this->getValues();
 


### PR DESCRIPTION
This removes the Multiple Submit Buttons Hacks from `ScheduleForm`, `ReportForm`, `TemplateForm`, and `TimeFrameForm`. it also adds PHPDocs and Typo annotation where possible.

fixes #164