### PR TITLE
Drop usage of `flatpickr` in `TimeframeForm`

### DIFF
--- a/application/controllers/TimeframeController.php
+++ b/application/controllers/TimeframeController.php
@@ -4,11 +4,11 @@
 
 namespace Icinga\Module\Reporting\Controllers;
 
-use GuzzleHttp\Psr7\ServerRequest;
 use Icinga\Module\Reporting\Database;
 use Icinga\Module\Reporting\Timeframe;
 use Icinga\Module\Reporting\Web\Controller;
 use Icinga\Module\Reporting\Web\Forms\TimeframeForm;
+use ipl\Web\Url;
 
 class TimeframeController extends Controller
 {
@@ -33,13 +33,14 @@ class TimeframeController extends Controller
             'end'   => $this->timeframe->getEnd()
         ];
 
-
         $form = TimeframeForm::fromId($this->timeframe->getId())
-            ->on(TimeframeForm::ON_SUCCESS, function () {
-                $this->redirectNow('reporting/timeframes');
-            })
+            ->setAction((string) Url::fromRequest())
             ->populate($values)
-            ->handleRequest(ServerRequest::fromGlobals());
+            ->on(TimeframeForm::ON_SUCCESS, function () {
+                $this->getResponse()->setHeader('X-Icinga-Container', 'modal-content', true);
+
+                $this->redirectNow('__CLOSE__');
+            })->handleRequest($this->getServerRequest());
 
         $this->addContent($form);
     }

--- a/library/Reporting/Web/Forms/TimeframeForm.php
+++ b/library/Reporting/Web/Forms/TimeframeForm.php
@@ -5,9 +5,11 @@
 namespace Icinga\Module\Reporting\Web\Forms;
 
 use DateTime;
+use Exception;
 use Icinga\Module\Reporting\Database;
 use ipl\Html\Contract\FormSubmitElement;
 use ipl\Html\FormElement\LocalDateTimeElement;
+use ipl\Validator\CallbackValidator;
 use ipl\Web\Compat\CompatForm;
 
 class TimeframeForm extends CompatForm
@@ -82,7 +84,22 @@ class TimeframeForm extends CompatForm
                 'required'    => true,
                 'label'       => $this->translate('Start'),
                 'placeholder' => $this->translate('First day of this month'),
-                'description' => $this->translate('Specifies the start time of this timeframe')
+                'description' => $this->translate('Specifies the start time of this timeframe'),
+                'validators' => [
+                    new CallbackValidator(function ($value, CallbackValidator $validator) {
+                        if ($value !== null) {
+                            try {
+                                new DateTime($value);
+                            } catch (Exception $_) {
+                                $validator->addMessage($this->translate('Invalid textual date time'));
+
+                                return false;
+                            }
+                        }
+
+                        return true;
+                    })
+                ]
             ]);
         }
 
@@ -124,7 +141,22 @@ class TimeframeForm extends CompatForm
                 'required'    => true,
                 'label'       => $this->translate('End'),
                 'placeholder' => $this->translate('Last day of this month'),
-                'description' => $this->translate('Specifies the end time of this timeframe')
+                'description' => $this->translate('Specifies the end time of this timeframe'),
+                'validators' => [
+                    new CallbackValidator(function ($value, CallbackValidator $validator) {
+                        if ($value !== null) {
+                            try {
+                                new DateTime($value);
+                            } catch (Exception $_) {
+                                $validator->addMessage($this->translate('Invalid textual date time'));
+
+                                return false;
+                            }
+                        }
+
+                        return true;
+                    })
+                ]
             ]);
         }
 


### PR DESCRIPTION
This PR removes the use of `flatpickr` and replaces it with `localdatetime`, which automatically fixes the issues mentioned below. Additionally, modals can now be used to create and edit time frames.

fixes #128, #154, #172

closes #151