### PR TITLE
Don't override scheduled schedules with the new ones

### DIFF
--- a/application/clicommands/ScheduleCommand.php
+++ b/application/clicommands/ScheduleCommand.php
@@ -61,10 +61,12 @@ class ScheduleCommand extends Command
                 );
 
                 $scheduler->remove($schedule);
+
+                unset($runningSchedules[$schedule->getUuid()->toString()]);
             }
 
             $newSchedules = array_diff_key($schedules, $runningSchedules);
-            foreach ($newSchedules as $schedule) {
+            foreach ($newSchedules as $key => $schedule) {
                 $config = $schedule->getConfig();
                 $frequency = $config['frequency'];
 
@@ -84,9 +86,9 @@ class ScheduleCommand extends Command
                 }
 
                 $scheduler->schedule($schedule, $frequency);
-            }
 
-            $runningSchedules = $schedules;
+                $runningSchedules[$key] = $schedule;
+            }
 
             Loop::addTimer(5 * 60, $watchdog);
         };
@@ -105,7 +107,7 @@ class ScheduleCommand extends Command
 
         foreach ($query as $schedule) {
             $schedule = Schedule::fromModel($schedule, Report::fromModel($schedule->report));
-            $schedules[$schedule->getChecksum()] = $schedule;
+            $schedules[$schedule->getUuid()->toString()] = $schedule;
         }
 
         return $schedules;


### PR DESCRIPTION
Fixes a daemon crash when reloading the schedules after `5m`.
```php
Removing Schedule1 as it either no longer exists in the database or its config has been changed
PHP Fatal error:  Uncaught InvalidArgumentException: Task Schedule1 not scheduled in /usr/local/src/ipl-scheduler/src/Scheduler.php:159
Stack trace:
#0 /usr/share/icingaweb2-modules/reporting/application/clicommands/ScheduleCommand.php(63): ipl\Scheduler\Scheduler->remove(Object(Icinga\Module\Reporting\Schedule))
#1 /usr/share/icinga-php/vendor/vendor/react/event-loop/src/ExtEvLoop.php(144): Icinga\Module\Reporting\Clicommands\ScheduleCommand->Icinga\Module\Reporting\Clicommands\{closure}(Object(React\EventLoop\Timer\Timer))
#2 [internal function]: React\EventLoop\ExtEvLoop->React\EventLoop\{closure}()
#3 /usr/share/icinga-php/vendor/vendor/react/event-loop/src/ExtEvLoop.php(208): EvLoop->run(2)
#4 /usr/share/icinga-php/vendor/vendor/react/event-loop/src/Loop.php(55): React\EventLoop\ExtEvLoop->run()
#5 [internal function]: React\EventLoop\Loop::React\EventLoop\{closure}()
#6 {main}
  thrown in /usr/local/src/ipl-scheduler/src/Scheduler.php on line 159
```