### PR TITLE
CoverPage: Don't use `StyleWithNonce` for cli interactions

### DIFF
--- a/library/Reporting/Web/Widget/CoverPage.php
+++ b/library/Reporting/Web/Widget/CoverPage.php
@@ -2,10 +2,12 @@
 
 namespace Icinga\Module\Reporting\Web\Widget;
 
+use Icinga\Application\Icinga;
 use Icinga\Module\Reporting\Common\Macros;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\Html;
 use ipl\Web\Compat\StyleWithNonce;
+use ipl\Web\Style;
 
 class CoverPage extends BaseHtmlElement
 {
@@ -139,7 +141,13 @@ class CoverPage extends BaseHtmlElement
     protected function assemble()
     {
         if ($this->hasBackgroundImage()) {
-            $coverPageBackground = (new StyleWithNonce())
+            if (Icinga::app()->isWeb()) {
+                $coverPageBackground = new StyleWithNonce();
+            } else {
+                $coverPageBackground = new Style();
+            }
+
+            $coverPageBackground
                 ->setModule('reporting')
                 ->addFor($this, [
                     'background-image' => sprintf("url('%s')", Template::getDataUrl($this->getBackgroundImage()))
@@ -150,7 +158,13 @@ class CoverPage extends BaseHtmlElement
 
         $content = Html::tag('div', ['class' => 'cover-page-content']);
         if ($this->hasColor()) {
-            $coverPageLogo = (new StyleWithNonce())
+            if (Icinga::app()->isWeb()) {
+                $coverPageLogo = new StyleWithNonce();
+            } else {
+                $coverPageLogo = new Style();
+            }
+
+            $coverPageLogo
                 ->setModule('reporting')
                 ->addFor($content, ['color' => $this->getColor()]);
 


### PR DESCRIPTION
**Before:**
```php
PHP Fatal error:  Uncaught Error: Call to undefined method Icinga\Application\Cli::getRequest() in /icingaweb2/library/Icinga/Web/Window.php:114
Stack trace:
#0 /icingaweb2/library/Icinga/Util/Csp.php(90): Icinga\Web\Window::getInstance()
#1 /icingaweb2/library/Icinga/Util/Csp.php(78): Icinga\Util\Csp::getInstance()
#2 /usr/local/src/ipl-web/src/Compat/StyleWithNonce.php(19): Icinga\Util\Csp::getStyleNonce()
#3 /usr/local/src/ipl-web/src/Style.php(105): ipl\Web\Compat\StyleWithNonce->getNonce()
```