### PR TITLE
DbMigration: Break once a correct schema version is found

### DIFF
--- a/library/Reporting/ProvidedHook/DbMigration.php
+++ b/library/Reporting/ProvidedHook/DbMigration.php
@@ -53,6 +53,8 @@ class DbMigration extends DbMigrationHook
                 foreach ($schema as $version) {
                     if ($version->success) {
                         $this->version = $version->version;
+
+                        break;
                     }
                 }
 


### PR DESCRIPTION
The schema versions are queried in descending order and limited to 2, and it should be stopped as soon as it has found the first possible version with `success` set to true.