### PR TITLE
Db: Fix current week timeframe end

### DIFF
--- a/library/Reporting/ProvidedHook/DbMigration.php
+++ b/library/Reporting/ProvidedHook/DbMigration.php
@@ -25,7 +25,8 @@ class DbMigration extends DbMigrationHook
                 . ' engine of some tables.'
             ),
             '0.10.0' => $this->translate('Creates the template table and adjusts some column types'),
-            '1.0.0'  => $this->translate('Migrates all your configured report schedules to the new config.')
+            '1.0.0'  => $this->translate('Migrates all your configured report schedules to the new config.'),
+            '1.0.3'  => $this->translate('Fix the `end` time of preconfigured `Current Week` timeframe.'),
         ];
     }
 

--- a/schema/mysql-upgrades/1.0.3.sql
+++ b/schema/mysql-upgrades/1.0.3.sql
@@ -1,0 +1,4 @@
+UPDATE timeframe SET end = 'now' WHERE name = 'Current Week';
+
+INSERT INTO reporting_schema (version, timestamp, success, reason)
+  VALUES ('1.0.3', unix_timestamp() * 1000, 'y', NULL);

--- a/schema/mysql.schema.sql
+++ b/schema/mysql.schema.sql
@@ -28,7 +28,7 @@ INSERT INTO timeframe (name, title, start, end, ctime, mtime) VALUES
   ('One Year', null, '-1 year', 'now', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
   ('Current Day', null, 'midnight', 'now', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
   ('Last Day', null, 'yesterday midnight', 'yesterday 23:59:59', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
-  ('Current Week', null, 'monday this week midnight', 'sunday this week 23:59:59', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
+  ('Current Week', null, 'monday this week midnight', 'now', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
   ('Last Week', null, 'monday last week midnight', 'sunday last week 23:59:59', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
   ('Current Month', null, 'first day of this month midnight', 'now', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),
   ('Last Month', null, 'first day of last month midnight', 'last day of last month 23:59:59', UNIX_TIMESTAMP() * 1000, UNIX_TIMESTAMP() * 1000),

--- a/schema/pgsql-upgrades/1.0.3.sql
+++ b/schema/pgsql-upgrades/1.0.3.sql
@@ -1,0 +1,4 @@
+UPDATE timeframe SET end = 'now' WHERE name = 'Current Week';
+
+INSERT INTO reporting_schema (version, timestamp, success, reason)
+  VALUES ('1.0.3', unix_timestamp() * 1000, 'y', NULL);

--- a/schema/pgsql.schema.sql
+++ b/schema/pgsql.schema.sql
@@ -31,7 +31,7 @@ INSERT INTO timeframe (name, title, start, "end") VALUES
   ('One Year', null, '-1 year', 'now'),
   ('Current Day', null, 'midnight', 'now'),
   ('Last Day', null, 'yesterday midnight', 'yesterday 23:59:59'),
-  ('Current Week', null, 'monday this week midnight', 'sunday this week 23:59:59'),
+  ('Current Week', null, 'monday this week midnight', 'now'),
   ('Last Week', null, 'monday last week midnight', 'sunday last week 23:59:59'),
   ('Current Month', null, 'first day of this month midnight', 'now'),
   ('Last Month', null, 'first day of last month midnight', 'last day of last month 23:59:59'),


### PR DESCRIPTION
The end value for the preconfigured time frame `Current week` is set to the upcoming Sunday, which leads that the reports contain false positive (future) data. The end must be set to `now`.