### PR TITLE
configuration.php: Define a icon and priority for the menu integration

### DIFF
--- a/configuration.php
+++ b/configuration.php
@@ -8,9 +8,8 @@ namespace Icinga\Module\Reporting {
 
     $this->provideCssFile('system-report.css');
 
-    $this->menuSection(N_('Reporting'))->add(N_('Reports'), array(
-        'url' => 'reporting/reports',
-    ));
+    $this->menuSection(N_('Reporting'), ['icon' => 'fa-chart-simple', 'priority' => 100])
+        ->add(N_('Reports'), ['url' => 'reporting/reports', 'priority' => 10]);
 
     $this->provideConfigTab('backend', array(
         'title' => $this->translate('Configure the database backend'),


### PR DESCRIPTION
Both are synchronized with the monitoring and cube module now. No matter which one is enabled, the section looks always the same.

fixes #249