### PR TITLE
Db: Quote "end" in PostgreSQL schema patch

### DIFF
--- a/schema/pgsql-upgrades/1.0.4.sql
+++ b/schema/pgsql-upgrades/1.0.4.sql
@@ -1,0 +1,4 @@
+UPDATE timeframe SET "end" = 'now' WHERE name = 'Current Week';
+
+INSERT INTO reporting_schema (version, timestamp, success, reason)
+  VALUES ('1.0.4', unix_timestamp() * 1000, 'y', NULL);


### PR DESCRIPTION
Without quoting, this won't apply cleanly and results in a failed migration.

I've bumped the version to 1.0.4, not sure if this is appropriate or not.

Fixes #252 