### PR TITLE
ReportForm: Select a proper expression when checking uniqueness

### DIFF
--- a/library/Reporting/Web/Forms/ReportForm.php
+++ b/library/Reporting/Web/Forms/ReportForm.php
@@ -11,6 +11,7 @@ use Icinga\Module\Reporting\ProvidedReports;
 use Icinga\Module\Reporting\RetryConnection;
 use ipl\Html\Form;
 use ipl\Html\HtmlDocument;
+use ipl\Sql\Expression;
 use ipl\Stdlib\Filter;
 use ipl\Validator\CallbackValidator;
 use ipl\Web\Compat\CompatForm;
@@ -133,7 +134,7 @@ class ReportForm extends CompatForm
                     }
 
                     $report = Report::on($this->db)
-                        ->columns('1')
+                        ->columns([new Expression('1')])
                         ->filter($filter)
                         ->first();
 


### PR DESCRIPTION
ipl\Orm translates this, due to a quirk in PHP where numerical strings are interpreted as integer keys in arrays, to the second column of the given base model. This is undocumented behavior and must be avoided.