### PR TITLE
Replace deprecated methods and interfaces of `react/promise`

### DIFF
--- a/application/clicommands/ScheduleCommand.php
+++ b/application/clicommands/ScheduleCommand.php
@@ -18,7 +18,7 @@ use ipl\Scheduler\Contract\Frequency;
 use ipl\Scheduler\Contract\Task;
 use ipl\Scheduler\Scheduler;
 use React\EventLoop\Loop;
-use React\Promise\ExtendedPromiseInterface;
+use React\Promise\PromiseInterface;
 use Throwable;
 
 class ScheduleCommand extends Command
@@ -121,7 +121,7 @@ class ScheduleCommand extends Command
             Logger::debug($e->getTraceAsString());
         });
 
-        $scheduler->on(Scheduler::ON_TASK_RUN, function (Task $job, ExtendedPromiseInterface $_) {
+        $scheduler->on(Scheduler::ON_TASK_RUN, function (Task $job, PromiseInterface $_) {
             Logger::info('Running job %s', $job->getName());
         });
 

--- a/library/Reporting/Actions/SendMail.php
+++ b/library/Reporting/Actions/SendMail.php
@@ -55,7 +55,7 @@ class SendMail extends ActionHook
                         $mail->attachPdf($pdf, $name);
                         $mail->send(null, $recipients);
                     }
-                )->otherwise(function (Throwable $e) {
+                )->catch(function (Throwable $e) {
                     Logger::error($e);
                     Logger::debug($e->getTraceAsString());
                 });

--- a/library/Reporting/Schedule.php
+++ b/library/Reporting/Schedule.php
@@ -12,7 +12,7 @@ use ipl\Scheduler\Contract\Task;
 use Ramsey\Uuid\Uuid;
 use React\EventLoop\Loop;
 use React\Promise;
-use React\Promise\ExtendedPromiseInterface;
+use React\Promise\PromiseInterface;
 
 use function md5;
 
@@ -128,7 +128,7 @@ class Schedule implements Task
         );
     }
 
-    public function run(): ExtendedPromiseInterface
+    public function run(): PromiseInterface
     {
         $deferred = new Promise\Deferred();
         Loop::futureTick(function () use ($deferred) {
@@ -144,12 +144,9 @@ class Schedule implements Task
                 return;
             }
 
-            $deferred->resolve();
+            $deferred->resolve(null);
         });
 
-        /** @var ExtendedPromiseInterface $promise */
-        $promise = $deferred->promise();
-
-        return $promise;
+        return $deferred->promise();
     }
 }


### PR DESCRIPTION
Replace deprecated methods and interfaces of `react/promise`
    
- Can no longer `resolve()` a promise without a value, use `null` instead.
- Method `otherwise()` is deprecated, use `catch()` instead.
- `(Extended|Cancellable)PromiseInterface` are removed since `v3.0.0`:
   https://reactphp.org/promise/changelog.html#300-2023-07-11

requires: 

- [x] Icinga/icinga-php-thirdparty#93

refs #261
