### PR TITLE
clicommands: Raise memory and exec limits like in Web

### DIFF
--- a/application/clicommands/DownloadCommand.php
+++ b/application/clicommands/DownloadCommand.php
@@ -10,6 +10,7 @@ use Icinga\Module\Reporting\Cli\Command;
 use Icinga\Module\Reporting\Database;
 use Icinga\Module\Reporting\Model;
 use Icinga\Module\Reporting\Report;
+use Icinga\Util\Environment;
 use InvalidArgumentException;
 use ipl\Stdlib\Filter;
 
@@ -57,6 +58,9 @@ class DownloadCommand extends Command
         if ($report === null) {
             throw new NotFoundError('Report not found');
         }
+
+        Environment::raiseExecutionTime();
+        Environment::raiseMemoryLimit();
 
         $report = Report::fromModel($report);
 

--- a/application/clicommands/ScheduleCommand.php
+++ b/application/clicommands/ScheduleCommand.php
@@ -14,6 +14,7 @@ use Icinga\Module\Reporting\Database;
 use Icinga\Module\Reporting\Model;
 use Icinga\Module\Reporting\Report;
 use Icinga\Module\Reporting\Schedule;
+use Icinga\Util\Environment;
 use ipl\Scheduler\Contract\Frequency;
 use ipl\Scheduler\Contract\Task;
 use ipl\Scheduler\Scheduler;
@@ -34,6 +35,10 @@ class ScheduleCommand extends Command
     {
         $scheduler = new Scheduler();
         $this->attachJobsLogging($scheduler);
+
+        // Reports may require more time and memory
+        Environment::raiseExecutionTime();
+        Environment::raiseMemoryLimit();
 
         /** @var Schedule[] $runningSchedules */
         $runningSchedules = [];


### PR DESCRIPTION
Had the daemon running for a few hours yesterday and sent me a report for 17k services and thus a PDF with 900+ pages each hour. Didn't notice any buildup in memory. The only thing missing would be a dynamic limit, as it may still crash to produce reports with a large timeframe and a low breakdown. But such a report crashes the UI as well so both parts, UI and CLI, should now be in line and behave the same at least.

fixes #242