### PR TITLE
Upgrade minimum required versions of ipl and icinga-php-thirdparty

### DIFF
--- a/doc/80-Upgrading.md
+++ b/doc/80-Upgrading.md
@@ -13,11 +13,9 @@ path to the correct installation path.
 
 ## Upgrading to Version 1.1.0
 
-Icinga Reporting version 1.1.0 raises the minimum required versions of
-`icinga-php-library` to `>=1.0.0` and `icinga-php-thirdparty` to `>=1.0.0`.
-This is due to the removal of `clue/block-react` from `icinga-php-thirdparty`.
-
-Please make sure to upgrade these libraries before upgrading this module.
+Icinga Reporting 1.1.0 now requires `icinga-php-library` version 1.0.0 or later
+and `icinga-php-thirdparty` version 1.0.0 or later to support PHP 8.5. Make
+sure to upgrade these libraries along with the module upgrade.
 
 ## Upgrading to Version 1.0.3
 

--- a/doc/80-Upgrading.md
+++ b/doc/80-Upgrading.md
@@ -11,6 +11,14 @@ path to the correct installation path.
 
 <!-- {% endif %} -->
 
+## Upgrading to Version 1.1.0
+
+Icinga Reporting version 1.1.0 raises the minimum required versions of
+`icinga-php-library` to `>=1.0.0` and `icinga-php-thirdparty` to `>=1.0.0`.
+This is due to the removal of `clue/block-react` from `icinga-php-thirdparty`.
+
+Please make sure to upgrade these libraries before upgrading this module.
+
 ## Upgrading to Version 1.0.3
 
 Icinga Reporting version 1.0.3 requires a schema update for the database.

--- a/module.info
+++ b/module.info
@@ -1,6 +1,6 @@
 Module: Reporting
 Version: 1.0.5
 Requires:
-  Libraries: icinga-php-library (>=0.13.0), icinga-php-thirdparty (>=0.12.0)
+  Libraries: icinga-php-library (>=1.0.0), icinga-php-thirdparty (>=1.0.0)
   Modules: pdfexport (>=0.11.0)
 Description: Reporting


### PR DESCRIPTION
Raises the minimum required version of icinga-php-library to >=1.0.0 and icinga-php-thirdparty to >=1.0.0.

icinga-php-thirdparty 1.0.0 updates react/promise from 2.11.0 to 3.3.0 to support PHP 8.5: 
- PHP 8.4 support was introduced in v3.2.0
- PHP 8.5 support in v3.3.0.

Earlier versions of this module depended on that package being available through icinga-php-thirdparty, so requiring at least 1.0.0 ensures compatibility with the updated dependency set.

Add upgrading notes for version 1.1.0.