### PR TITLE
Switch back to using syncronous pdf export

### DIFF
--- a/application/clicommands/DownloadCommand.php
+++ b/application/clicommands/DownloadCommand.php
@@ -5,6 +5,7 @@
 
 namespace Icinga\Module\Reporting\Clicommands;
 
+use Icinga\Application\Hook\PdfexportHook;
 use Icinga\Exception\NotFoundError;
 use Icinga\Module\Pdfexport\ProvidedHook\Pdfexport;
 use Icinga\Module\Reporting\Cli\Command;
@@ -70,7 +71,11 @@ class DownloadCommand extends Command
         $format = strtolower($format);
         switch ($format) {
             case 'pdf':
-                $content = Pdfexport::first()->htmlToPdf($report->toPdf());
+                // TODO: Remove this once the dependency on the Pdfexport module is removed
+                $exporter = method_exists(PdfexportHook::class, 'first')
+                    ? PdfexportHook::first()
+                    : Pdfexport::first();
+                $content = $exporter->htmlToPdf($report->toPdf());
                 break;
             case 'csv':
                 $content = $report->toCsv();

--- a/application/clicommands/DownloadCommand.php
+++ b/application/clicommands/DownloadCommand.php
@@ -5,6 +5,7 @@
 
 namespace Icinga\Module\Reporting\Clicommands;
 
+use Icinga\Application\Hook\PdfexportHook;
 use Icinga\Exception\NotFoundError;
 use Icinga\Module\Pdfexport\ProvidedHook\Pdfexport;
 use Icinga\Module\Reporting\Cli\Command;
@@ -70,7 +71,12 @@ class DownloadCommand extends Command
         $format = strtolower($format);
         switch ($format) {
             case 'pdf':
-                $content = Pdfexport::first()->htmlToPdf($report->toPdf());
+                // TODO: Remove this once the dependency on the Pdfexport module is removed
+                /** @var PdfexportHook $exporter */
+                $exporter = method_exists(PdfexportHook::class, 'first')
+                    ? PdfexportHook::first()
+                    : Pdfexport::first();
+                $content = $exporter->htmlToPdf($report->toPdf());
                 break;
             case 'csv':
                 $content = $report->toCsv();

--- a/application/controllers/ReportController.php
+++ b/application/controllers/ReportController.php
@@ -7,6 +7,7 @@ namespace Icinga\Module\Reporting\Controllers;
 
 use Exception;
 use Icinga\Application\Hook;
+use Icinga\Application\Hook\PdfexportHook;
 use Icinga\Module\Pdfexport\ProvidedHook\Pdfexport;
 use Icinga\Module\Reporting\Database;
 use Icinga\Module\Reporting\Model;
@@ -244,9 +245,11 @@ class ReportController extends Controller
 
         switch ($type) {
             case 'pdf':
-                /** @var Hook\PdfexportHook $exports */
-                $exports = Pdfexport::first();
-                $exports->streamPdfFromHtml($this->report->toPdf(), $name);
+                // TODO: Remove this once the dependency on the Pdfexport module is removed
+                $exporter = method_exists(PdfexportHook::class, 'first')
+                    ? PdfexportHook::first()
+                    : Pdfexport::first();
+                $exporter->streamPdfFromHtml($this->report->toPdf(), $name);
                 exit;
             case 'csv':
                 $response = $this->getResponse();

--- a/application/controllers/ReportController.php
+++ b/application/controllers/ReportController.php
@@ -6,7 +6,7 @@
 namespace Icinga\Module\Reporting\Controllers;
 
 use Exception;
-use Icinga\Application\Hook;
+use Icinga\Application\Hook\PdfexportHook;
 use Icinga\Module\Pdfexport\ProvidedHook\Pdfexport;
 use Icinga\Module\Reporting\Database;
 use Icinga\Module\Reporting\Model;
@@ -244,9 +244,12 @@ class ReportController extends Controller
 
         switch ($type) {
             case 'pdf':
-                /** @var Hook\PdfexportHook $exports */
-                $exports = Pdfexport::first();
-                $exports->streamPdfFromHtml($this->report->toPdf(), $name);
+                // TODO: Remove this once the dependency on the Pdfexport module is removed
+                /** @var PdfexportHook $exporter */
+                $exporter = method_exists(PdfexportHook::class, 'first')
+                    ? PdfexportHook::first()
+                    : Pdfexport::first();
+                $exporter->streamPdfFromHtml($this->report->toPdf(), $name);
                 exit;
             case 'csv':
                 $response = $this->getResponse();

--- a/library/Reporting/Actions/SendMail.php
+++ b/library/Reporting/Actions/SendMail.php
@@ -49,17 +49,9 @@ class SendMail extends ActionHook
 
         switch ($config['type']) {
             case 'pdf':
-                $exporter = Pdfexport::first();
-                try {
-                    $pdf = $exporter->htmlToPdf($report->toPdf());
-                    $mail->attachPdf($pdf, $name);
-                    $mail->send(null, $recipients);
-                } catch (Throwable $e) {
-                    Logger::error($e);
-                    Logger::debug($e->getTraceAsString());
-                }
+                $mail->attachPdf(Pdfexport::first()->htmlToPdf($report->toPdf()), $name);
 
-                return;
+                break;
             case 'csv':
                 $mail->attachCsv($report->toCsv(), $name);
 

--- a/library/Reporting/Actions/SendMail.php
+++ b/library/Reporting/Actions/SendMail.php
@@ -49,17 +49,15 @@ class SendMail extends ActionHook
 
         switch ($config['type']) {
             case 'pdf':
-                /** @var Pdfexport $exporter */
                 $exporter = Pdfexport::first();
-                $exporter->asyncHtmlToPdf($report->toPdf())->then(
-                    function ($pdf) use ($mail, $name, $recipients) {
-                        $mail->attachPdf($pdf, $name);
-                        $mail->send(null, $recipients);
-                    }
-                )->catch(function (Throwable $e) {
+                try {
+                    $pdf = $exporter->htmlToPdf($report->toPdf());
+                    $mail->attachPdf($pdf, $name);
+                    $mail->send(null, $recipients);
+                } catch (Throwable $e) {
                     Logger::error($e);
                     Logger::debug($e->getTraceAsString());
-                });
+                }
 
                 return;
             case 'csv':

--- a/library/Reporting/Actions/SendMail.php
+++ b/library/Reporting/Actions/SendMail.php
@@ -6,7 +6,7 @@
 namespace Icinga\Module\Reporting\Actions;
 
 use Icinga\Application\Config;
-use Icinga\Application\Logger;
+use Icinga\Application\Hook\PdfexportHook;
 use Icinga\Module\Pdfexport\ProvidedHook\Pdfexport;
 use Icinga\Module\Reporting\Hook\ActionHook;
 use Icinga\Module\Reporting\Mail;
@@ -15,7 +15,6 @@ use ipl\Html\Form;
 use ipl\Stdlib\Str;
 use ipl\Validator\CallbackValidator;
 use ipl\Validator\EmailAddressValidator;
-use Throwable;
 
 class SendMail extends ActionHook
 {
@@ -49,7 +48,11 @@ class SendMail extends ActionHook
 
         switch ($config['type']) {
             case 'pdf':
-                $mail->attachPdf(Pdfexport::first()->htmlToPdf($report->toPdf()), $name);
+                // TODO: Remove this once the dependency on the Pdfexport module is removed
+                $exporter = method_exists(PdfexportHook::class, 'first')
+                    ? PdfexportHook::first()
+                    : Pdfexport::first();
+                $mail->attachPdf($exporter->htmlToPdf($report->toPdf()), $name);
 
                 break;
             case 'csv':

--- a/library/Reporting/Actions/SendMail.php
+++ b/library/Reporting/Actions/SendMail.php
@@ -6,7 +6,7 @@
 namespace Icinga\Module\Reporting\Actions;
 
 use Icinga\Application\Config;
-use Icinga\Application\Logger;
+use Icinga\Application\Hook\PdfexportHook;
 use Icinga\Module\Pdfexport\ProvidedHook\Pdfexport;
 use Icinga\Module\Reporting\Hook\ActionHook;
 use Icinga\Module\Reporting\Mail;
@@ -15,7 +15,6 @@ use ipl\Html\Form;
 use ipl\Stdlib\Str;
 use ipl\Validator\CallbackValidator;
 use ipl\Validator\EmailAddressValidator;
-use Throwable;
 
 class SendMail extends ActionHook
 {
@@ -49,7 +48,12 @@ class SendMail extends ActionHook
 
         switch ($config['type']) {
             case 'pdf':
-                $mail->attachPdf(Pdfexport::first()->htmlToPdf($report->toPdf()), $name);
+                // TODO: Remove this once the dependency on the Pdfexport module is removed
+                /** @var PdfexportHook $exporter */
+                $exporter = method_exists(PdfexportHook::class, 'first')
+                    ? PdfexportHook::first()
+                    : Pdfexport::first();
+                $mail->attachPdf($exporter->htmlToPdf($report->toPdf()), $name);
 
                 break;
             case 'csv':

--- a/library/Reporting/Actions/SendMail.php
+++ b/library/Reporting/Actions/SendMail.php
@@ -49,19 +49,9 @@ class SendMail extends ActionHook
 
         switch ($config['type']) {
             case 'pdf':
-                /** @var Pdfexport $exporter */
-                $exporter = Pdfexport::first();
-                $exporter->asyncHtmlToPdf($report->toPdf())->then(
-                    function ($pdf) use ($mail, $name, $recipients) {
-                        $mail->attachPdf($pdf, $name);
-                        $mail->send(null, $recipients);
-                    }
-                )->catch(function (Throwable $e) {
-                    Logger::error($e);
-                    Logger::debug($e->getTraceAsString());
-                });
+                $mail->attachPdf(Pdfexport::first()->htmlToPdf($report->toPdf()), $name);
 
-                return;
+                break;
             case 'csv':
                 $mail->attachCsv($report->toCsv(), $name);
 


### PR DESCRIPTION
The reason we initially switched to `asyncHtmlToPdf` was because the headless chrome backend tried to create its own event loop, which caused problems with ipl-scheduler.

The new pdfexport module no longer has this behavior. Therefore, `asyncHtmlToPdf` is no longer required.
The method was never actually part of the hook and therefore relied on the fact that pdfexport was the only implementation of `PdfexportHook`.
