### PR TITLE
Conditional report actions

### DIFF
--- a/application/controllers/ReportController.php
+++ b/application/controllers/ReportController.php
@@ -335,15 +335,17 @@ class ReportController extends Controller
             );
         }
 
-        $actions
-            ->add($download)
-            ->addHtml(
-                (new ActionLink(
-                    $this->translate('Send'),
-                    Url::fromPath('reporting/report/send', ['id' => $reportId]),
-                    'forward'
-                ))->openInModal()
-            );
+        if ($download->hasLinks()) {
+            $actions
+                ->add($download)
+                ->addHtml(
+                    (new ActionLink(
+                        $this->translate('Send'),
+                        Url::fromPath('reporting/report/send', ['id' => $reportId]),
+                        'forward'
+                    ))->openInModal()
+                );
+        }
 
         return $actions;
     }

--- a/application/controllers/ReportController.php
+++ b/application/controllers/ReportController.php
@@ -279,13 +279,16 @@ class ReportController extends Controller
     {
         $reportId = $this->report->getId();
 
-        $download = (new CompatDropdown('Download'))
-            ->addLink(
+        $download = new CompatDropdown('Download');
+
+        if (Hook::has('Pdfexport')) {
+            $download->addLink(
                 'PDF',
                 Url::fromPath('reporting/report/download?type=pdf', ['id' => $reportId]),
                 null,
                 ['target' => '_blank']
             );
+        }
 
         if ($this->report->providesData()) {
             $download->addLink(

--- a/application/controllers/ReportController.php
+++ b/application/controllers/ReportController.php
@@ -340,15 +340,17 @@ class ReportController extends Controller
             );
         }
 
-        $actions
-            ->add($download)
-            ->addHtml(
-                (new ActionLink(
-                    $this->translate('Send'),
-                    Url::fromPath('reporting/report/send', ['id' => $reportId]),
-                    'forward'
-                ))->openInModal()
-            );
+        if ($download->hasLinks()) {
+            $actions
+                ->add($download)
+                ->addHtml(
+                    (new ActionLink(
+                        $this->translate('Send'),
+                        Url::fromPath('reporting/report/send', ['id' => $reportId]),
+                        'forward'
+                    ))->openInModal()
+                );
+        }
 
         return $actions;
     }

--- a/application/controllers/ReportController.php
+++ b/application/controllers/ReportController.php
@@ -7,6 +7,7 @@ namespace Icinga\Module\Reporting\Controllers;
 
 use Exception;
 use Icinga\Application\Hook\PdfexportHook;
+use Icinga\Application\Modules\Module;
 use Icinga\Module\Pdfexport\ProvidedHook\Pdfexport;
 use Icinga\Module\Reporting\Database;
 use Icinga\Module\Reporting\Model;
@@ -282,13 +283,17 @@ class ReportController extends Controller
     {
         $reportId = $this->report->getId();
 
-        $download = (new CompatDropdown('Download'))
-            ->addLink(
+        $download = new CompatDropdown('Download');
+
+        // TODO: Check against Hook::has once we have removed the dependency on the pdfexport module
+        if (Module::exists('pdfexport')) {
+            $download->addLink(
                 'PDF',
                 Url::fromPath('reporting/report/download?type=pdf', ['id' => $reportId]),
                 null,
                 ['target' => '_blank']
             );
+        }
 
         if ($this->report->providesData()) {
             $download->addLink(

--- a/library/Reporting/Actions/SendMail.php
+++ b/library/Reporting/Actions/SendMail.php
@@ -6,6 +6,7 @@
 namespace Icinga\Module\Reporting\Actions;
 
 use Icinga\Application\Config;
+use Icinga\Application\Hook;
 use Icinga\Application\Logger;
 use Icinga\Module\Pdfexport\ProvidedHook\Pdfexport;
 use Icinga\Module\Reporting\Hook\ActionHook;
@@ -79,7 +80,11 @@ class SendMail extends ActionHook
 
     public function initConfigForm(Form $form, Report $report)
     {
-        $types = ['pdf' => 'PDF'];
+        $types = [];
+
+        if (Hook::has('Pdfexport')) {
+            $types['pdf'] = 'PDF';
+        }
 
         if ($report->providesData()) {
             $types['csv'] = 'CSV';

--- a/library/Reporting/Actions/SendMail.php
+++ b/library/Reporting/Actions/SendMail.php
@@ -7,6 +7,7 @@ namespace Icinga\Module\Reporting\Actions;
 
 use Icinga\Application\Config;
 use Icinga\Application\Hook\PdfexportHook;
+use Icinga\Application\Modules\Module;
 use Icinga\Module\Pdfexport\ProvidedHook\Pdfexport;
 use Icinga\Module\Reporting\Hook\ActionHook;
 use Icinga\Module\Reporting\Mail;
@@ -73,7 +74,12 @@ class SendMail extends ActionHook
 
     public function initConfigForm(Form $form, Report $report)
     {
-        $types = ['pdf' => 'PDF'];
+        $types = [];
+
+        // TODO: Check against Hook::has once we have removed the dependency on the pdfexport module
+        if (Module::exists('pdfexport')) {
+            $types['pdf'] = 'PDF';
+        }
 
         if ($report->providesData()) {
             $types['csv'] = 'CSV';


### PR DESCRIPTION
Only show actions if there is actually an exporter for it.

Draft for now because of an issue that prevents `PrintableHtmlDocument` to be moved to icingaweb https://github.com/Icinga/icingaweb2/pull/5510

- Remove PDF download option and mail attachment type when there is no pdfexport hook implementation registered
- Remove download dropdown and send button entirely if no export option is available 

This serves as a step toward getting rid of pdfexport as a requirement for reporting, but does not get rid of this dependency entirely.

This combined with the changes made in #275 should allow us to remove pdfexport as a requirement. It is still not possible to use any module that implements the Pdfexport hook but at least the module is able to show reports in the web app and export to CSV and JSON.

- requires https://github.com/Icinga/ipl-web/pull/367
- requires https://github.com/Icinga/icingaweb2/pull/5510
- relates to #275
